### PR TITLE
rendre plus explicite le fait d'enregistrer une disponibilité

### DIFF
--- a/views/calendar.hbs
+++ b/views/calendar.hbs
@@ -3,7 +3,7 @@
 
 <h1>
   Mon planning
-  <button type="button" class="pull-right btn btn-success btn-lg" data-toggle="modal" data-target="#book_leave_modal" id="book_time_off_btn">Enregistrer ma disponibilité</button>
+  <button type="button" class="pull-right btn btn-success btn-lg" data-toggle="modal" data-target="#book_leave_modal" id="book_time_off_btn">Enregistrer une disponibilité</button>
 </h1>
 
 <div class="row hidden">

--- a/views/partials/book_leave_modal.hbs
+++ b/views/partials/book_leave_modal.hbs
@@ -5,7 +5,7 @@
     <form method="POST" action="{{leave_modal_form_action}}">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title" id="exampleModalLabel">Enregistrer ma disponibilité</h4>
+        <h4 class="modal-title" id="exampleModalLabel">Enregistrer une disponibilité</h4>
       </div>
       <div class="modal-body">
 

--- a/views/team_view.hbs
+++ b/views/team_view.hbs
@@ -7,6 +7,11 @@
     <div class="col-md-6 lead">{{logged_user.name}} {{logged_user.lastname}}'s team <a href="/calendar/feeds/" data-toggle="tooltip" data-placement="right" title="Export Team View to external calendars"><span class="fa fa-rss"></span></a></div>
 </div>
 
+<h1>
+  Mon équipe
+  <button type="button" class="pull-right btn btn-success btn-lg" data-toggle="modal" data-target="#book_leave_modal" id="book_time_off_btn">Enregistrer une disponibilité</button>
+</h1>
+
 {{> show_flash_messages }}
 
 <div class="row hidden">&nbsp;</div>


### PR DESCRIPTION
Antoine,

Tu trouveras dans ces modifications
- j'ai changé sur la page "Mon planning" le texte du bouton de "Enregistrer ma disponibilité" en "Enregistrer une disponibilité".
- Quand on clique sur le bouton, cela affiche une fenêtre popup intitulée "Enregistrer ma disponibilité", j'ai changé le titre pour "Enregistrer une disponibilité".
- Enfin, sur la page a laquelle on accède après avoir cliqué sur le menu "Mon équipe", j'ai ajouté suivant la même mise en page que la page "Mon planning" un titre "Mon équipe" et le bouton "Enregistrer une disponibilité"

Merci de prendre en compte cette pull request.

PS, j'ai essayé de ne pas faire de fautes d'orthographe cette fois ci, histoire de diminuer le nombre de commits : )

Christophe